### PR TITLE
Tighten throw tech input contracts

### DIFF
--- a/scripts/Hud.gd
+++ b/scripts/Hud.gd
@@ -136,7 +136,8 @@ var training_options := {
 	"enabled": true,
 	"dummy_mode": "stand",
 	"show_detail": false,
-	"ruleset_profile": "duel"
+	"ruleset_profile": "duel",
+	"throw_tech_assist_mode": "throw_only"
 }
 var training_panel_visible := true
 var training_controls_visible := true
@@ -501,6 +502,12 @@ func set_training_options(options: Dictionary) -> void:
 	training_options["show_detail"] = bool(options.get("show_detail", training_options.get("show_detail", false)))
 	var ruleset_profile := str(options.get("ruleset_profile", training_options.get("ruleset_profile", "duel"))).strip_edges().to_lower()
 	training_options["ruleset_profile"] = "platform" if ruleset_profile == "platform" else "duel"
+	var throw_tech_assist_mode := str(
+		options.get("throw_tech_assist_mode", training_options.get("throw_tech_assist_mode", "throw_only"))
+	).strip_edges().to_lower()
+	if throw_tech_assist_mode not in ["off", "throw_only", "button_assist"]:
+		throw_tech_assist_mode = "throw_only"
+	training_options["throw_tech_assist_mode"] = throw_tech_assist_mode
 	_refresh_training_panel()
 
 func add_training_log_entry(info: Dictionary) -> void:

--- a/scripts/Match.gd
+++ b/scripts/Match.gd
@@ -91,7 +91,8 @@ const TRAINING_DEFAULT_OPTIONS := {
 	"enabled": true,
 	"dummy_mode": "stand",
 	"show_detail": false,
-	"ruleset_profile": RULESET_DUEL
+	"ruleset_profile": RULESET_DUEL,
+	"throw_tech_assist_mode": "throw_only"
 }
 const IMPACT_ANIMATION_TEXTURE_PATHS := {
 	"hit": [
@@ -911,6 +912,12 @@ func _normalize_ruleset_profile(profile: String) -> String:
 	if normalized == RULESET_PLATFORM:
 		return RULESET_PLATFORM
 	return RULESET_DUEL
+
+func _normalize_throw_tech_assist_mode(mode: String) -> String:
+	var normalized := str(mode).strip_edges().to_lower()
+	if normalized in ["off", "button_assist"]:
+		return normalized
+	return "throw_only"
 
 func _uses_platform_ruleset() -> bool:
 	return ruleset_profile == RULESET_PLATFORM
@@ -1802,6 +1809,10 @@ func _show_hit_type_feedback(training_info: Dictionary, is_block_event: bool) ->
 func _apply_training_options() -> void:
 	var enabled := bool(training_options.get("enabled", true))
 	var dummy_mode := str(training_options.get("dummy_mode", "stand"))
+	var throw_tech_assist_mode := _normalize_throw_tech_assist_mode(
+		str(training_options.get("throw_tech_assist_mode", "throw_only"))
+	)
+	training_options["throw_tech_assist_mode"] = throw_tech_assist_mode
 	if hud and hud.has_method("set_training_options"):
 		hud.set_training_options(training_options)
 	if not enabled and hud:
@@ -1813,6 +1824,10 @@ func _apply_training_options() -> void:
 		player_2.call("set_training_dummy_options", enabled, dummy_mode)
 	if player_1 and player_1.has_method("set_training_dummy_options"):
 		player_1.call("set_training_dummy_options", false, "stand")
+	if player_2 and player_2.has_method("set_training_throw_tech_options"):
+		player_2.call("set_training_throw_tech_options", enabled, throw_tech_assist_mode)
+	if player_1 and player_1.has_method("set_training_throw_tech_options"):
+		player_1.call("set_training_throw_tech_options", enabled, throw_tech_assist_mode)
 	if training_scene_enabled:
 		if player_2 != null:
 			player_2.set("is_ai", false)
@@ -1828,6 +1843,9 @@ func _on_hud_training_options_changed(options: Dictionary) -> void:
 	training_options["show_detail"] = bool(options.get("show_detail", training_options.get("show_detail", false)))
 	var requested_ruleset := _normalize_ruleset_profile(str(options.get("ruleset_profile", training_options.get("ruleset_profile", ruleset_profile))))
 	training_options["ruleset_profile"] = requested_ruleset
+	training_options["throw_tech_assist_mode"] = _normalize_throw_tech_assist_mode(
+		str(options.get("throw_tech_assist_mode", training_options.get("throw_tech_assist_mode", "throw_only")))
+	)
 	if training_scene_enabled and requested_ruleset != ruleset_profile:
 		ruleset_profile = requested_ruleset
 		_apply_ruleset_profile()

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -45,9 +45,13 @@ const TECH_SLIDE_DURATION := 0.12
 const TECH_SLIDE_SPEED := 180.0
 const WAKE_INVULN_SECONDS := 0.18
 const RESPAWN_INVULN_SECONDS := 0.72
-const THROW_TECH_BUFFER_SECONDS := 0.10
+const THROW_TECH_DUEL_BUFFER_SECONDS := 0.08
+const THROW_TECH_ASSIST_BUFFER_SECONDS := 0.03
 const THROW_TECH_PUSHBACK := 70.0
 const THROW_TECH_AI_CHANCE := 0.20
+const THROW_TECH_ASSIST_OFF := "off"
+const THROW_TECH_ASSIST_THROW_ONLY := "throw_only"
+const THROW_TECH_ASSIST_BUTTON_ASSIST := "button_assist"
 const AI_BLOCK_REACTION_DISTANCE := 76.0
 const AI_BLOCK_STARTUP_REACTION_THRESHOLD := 0.62
 const TRAINING_RANDOM_BLOCK_CHANCE := 0.5
@@ -579,9 +583,13 @@ var ai_tech_decision_roll := false
 var ai_guard_mode := "high"
 var ai_style_profile: Dictionary = AI_PROFILE_DEFAULT.duplicate(true)
 var throw_tech_buffer_time := 0.0
+var throw_tech_input_source := ""
+var throw_tech_window_type := ""
 var last_training_info := {}
 var training_dummy_enabled := false
 var training_dummy_mode := "stand"
+var training_throw_tech_enabled := false
+var training_throw_tech_assist_mode := THROW_TECH_ASSIST_OFF
 var training_random_block_hold_time := 0.0
 var training_random_block_signature := ""
 var skill_cooldowns: Dictionary = {}
@@ -1216,6 +1224,7 @@ func _start_spot_dodge() -> void:
 	if is_on_floor():
 		velocity.y = 0.0
 	_clear_attack_buffer()
+	_clear_throw_tech_buffer()
 
 func _start_roll_dodge(direction: int) -> void:
 	var resolved_direction := direction
@@ -1232,6 +1241,7 @@ func _start_roll_dodge(direction: int) -> void:
 	velocity.x = float(dodge_direction) * _get_roll_dodge_speed() * _get_move_speed_multiplier()
 	velocity.y = 0.0
 	_clear_attack_buffer()
+	_clear_throw_tech_buffer()
 
 func _start_air_dodge(horizontal_axis: float, vertical_axis: float) -> bool:
 	if not _allows_air_dodge():
@@ -1254,6 +1264,7 @@ func _start_air_dodge(horizontal_axis: float, vertical_axis: float) -> bool:
 	facing_locked = true
 	facing_locked_direction = dodge_direction
 	_clear_attack_buffer()
+	_clear_throw_tech_buffer()
 	return true
 
 func _update_dodge_motion(delta: float) -> void:
@@ -1819,6 +1830,18 @@ func set_training_dummy_options(enabled: bool, mode: String) -> void:
 		training_random_block_hold_time = 0.0
 		training_random_block_signature = ""
 		is_blocking = false
+
+func set_training_throw_tech_options(enabled: bool, assist_mode: String) -> void:
+	training_throw_tech_enabled = enabled
+	var normalized := str(assist_mode).strip_edges().to_lower()
+	if normalized not in [
+		THROW_TECH_ASSIST_OFF,
+		THROW_TECH_ASSIST_THROW_ONLY,
+		THROW_TECH_ASSIST_BUTTON_ASSIST
+	]:
+		normalized = THROW_TECH_ASSIST_THROW_ONLY
+	training_throw_tech_assist_mode = normalized
+	_clear_throw_tech_buffer()
 
 func get_training_dummy_options() -> Dictionary:
 	return {
@@ -3718,21 +3741,55 @@ func _consume_ultimate_chord_buffer() -> void:
 	special_input_buffer_time = 0.0
 	heavy_input_buffer_time = 0.0
 
+func _clear_throw_tech_buffer() -> void:
+	throw_tech_buffer_time = 0.0
+	throw_tech_input_source = ""
+	throw_tech_window_type = ""
+
+func _resolve_throw_tech_input_source() -> String:
+	if _is_action_just_pressed("throw"):
+		return "throw"
+	if _allows_throw_tech_button_assist():
+		if _is_action_just_pressed("attack_light"):
+			return "light"
+		if _is_action_just_pressed("attack_heavy"):
+			return "heavy"
+	return ""
+
+func _allows_throw_tech_button_assist() -> bool:
+	return training_throw_tech_enabled and training_throw_tech_assist_mode == THROW_TECH_ASSIST_BUTTON_ASSIST
+
+func _is_throw_tech_disabled_in_training() -> bool:
+	return training_throw_tech_enabled and training_throw_tech_assist_mode == THROW_TECH_ASSIST_OFF
+
+func _resolve_throw_tech_buffer_seconds(input_source: String) -> float:
+	match input_source:
+		"throw":
+			if _is_throw_tech_disabled_in_training():
+				return 0.0
+			return THROW_TECH_DUEL_BUFFER_SECONDS
+		"light", "heavy":
+			if _allows_throw_tech_button_assist():
+				return THROW_TECH_ASSIST_BUFFER_SECONDS
+	return 0.0
+
+func _prime_throw_tech_buffer(input_source: String) -> void:
+	var buffer_seconds := _resolve_throw_tech_buffer_seconds(input_source)
+	if buffer_seconds <= 0.0:
+		return
+	throw_tech_buffer_time = buffer_seconds
+	throw_tech_input_source = input_source
+	throw_tech_window_type = "assist" if input_source in ["light", "heavy"] else "duel"
+
 func _update_throw_tech_buffer(delta: float) -> void:
 	throw_tech_buffer_time = maxf(0.0, throw_tech_buffer_time - delta)
+	if throw_tech_buffer_time <= 0.0:
+		_clear_throw_tech_buffer()
 	if is_ai:
 		return
-	if _is_throw_tech_input_pressed():
-		throw_tech_buffer_time = THROW_TECH_BUFFER_SECONDS
-
-func _is_throw_tech_input_pressed() -> bool:
-	if _is_action_just_pressed("throw"):
-		return true
-	if _is_action_just_pressed("attack_light"):
-		return true
-	if _is_action_just_pressed("attack_heavy"):
-		return true
-	return false
+	var input_source := _resolve_throw_tech_input_source()
+	if input_source != "":
+		_prime_throw_tech_buffer(input_source)
 
 func _request_attack(kind: String) -> void:
 	if kind == "":
@@ -4468,7 +4525,9 @@ func _record_training_exchange(
 		"chip_damage": int(hit_result.get("chip_damage", 0)),
 		"hp_before": int(hit_result.get("hp_before", 0)),
 		"hp_after": int(hit_result.get("hp_after", 0)),
-		"is_counter": is_counter_hit
+		"is_counter": is_counter_hit,
+		"throw_tech_source": str(hit_result.get("throw_tech_source", "")),
+		"throw_tech_window_type": str(hit_result.get("throw_tech_window_type", ""))
 	}
 
 func _can_throw_tech(attack_meta: Dictionary) -> bool:
@@ -4484,7 +4543,7 @@ func _can_throw_tech(attack_meta: Dictionary) -> bool:
 		return false
 	if is_ai:
 		return randf() < THROW_TECH_AI_CHANCE
-	return throw_tech_buffer_time > 0.0
+	return throw_tech_buffer_time > 0.0 and throw_tech_input_source != ""
 
 func _apply_throw_tech_defense(knockback: Vector2) -> void:
 	var push_direction := signf(knockback.x)
@@ -4497,7 +4556,7 @@ func _apply_throw_tech_defense(knockback: Vector2) -> void:
 	is_blocking = false
 	is_dashing = false
 	guard_counter_time = 0.0
-	throw_tech_buffer_time = 0.0
+	_clear_throw_tech_buffer()
 	ai_block_time = 0.0
 	health_changed.emit()
 
@@ -4521,6 +4580,7 @@ func _apply_block_impact(
 	hitstun_time = 0.0
 	guard_counter_time = GUARD_COUNTER_WINDOW_SECONDS
 	is_dashing = false
+	_clear_throw_tech_buffer()
 	attack_state = ""
 	attack_phase = ""
 	attack_recovery_override = -1.0
@@ -4574,6 +4634,7 @@ func _trigger_shield_break() -> void:
 	landing_lag_time = 0.0
 	is_dashing = false
 	guard_counter_time = 0.0
+	_clear_throw_tech_buffer()
 	_clear_attack_state()
 	_clear_attack_buffer()
 	velocity.x = -float(facing) * SHIELD_BREAK_PUSHBACK
@@ -4735,11 +4796,14 @@ func apply_damage(
 		return result
 
 	if attack_kind == "throw" and _can_throw_tech(attack_meta):
+		var tech_source := throw_tech_input_source
+		var tech_window_type := throw_tech_window_type
 		_apply_throw_tech_defense(knockback)
 		result["throw_teched"] = true
 		result["guard_mode"] = "throw_break"
+		result["throw_tech_source"] = tech_source
+		result["throw_tech_window_type"] = tech_window_type
 		result["hp_after"] = current_hp
-		throw_tech_buffer_time = 0.0
 		return result
 
 	var guard_mode := _get_guard_mode()
@@ -4764,6 +4828,7 @@ func apply_damage(
 	velocity = final_knockback
 	hitstun_time = maxf(0.0, hitstun_override)
 	blockstun_time = 0.0
+	_clear_throw_tech_buffer()
 	hit_reaction_animation = _resolve_hit_reaction_animation(final_knockback, hitstun_override)
 	is_dashing = false
 	is_blocking = false
@@ -4853,7 +4918,7 @@ func force_respawn(spawn_position: Vector2, facing_direction: int = 1) -> void:
 	getup_time = 0.0
 	guard_counter_time = 0.0
 	wake_invuln_time = WAKE_INVULN_SECONDS
-	throw_tech_buffer_time = 0.0
+	_clear_throw_tech_buffer()
 	ai_block_time = 0.0
 	ai_attack_cooldown = 0.0
 	ai_tech_decision_roll = false

--- a/tests/TestRunner.gd
+++ b/tests/TestRunner.gd
@@ -1821,11 +1821,13 @@ func _test_training_toggle_keeps_dummy_non_ai() -> void:
 			"enabled": true,
 			"dummy_mode": "stand",
 			"show_detail": false,
-			"ruleset_profile": "platform"
+			"ruleset_profile": "platform",
+			"throw_tech_assist_mode": "button_assist"
 		})
 		await process_frame
 		_assert_true(not bool(p2.get("is_ai")), "switching training ruleset does not re-enable dummy ai")
 		_assert_true(str(training_node.get("ruleset_profile")) == "platform", "training ruleset toggle updates match ruleset")
+		_assert_true(str(p2.get("training_throw_tech_assist_mode")) == "button_assist", "training scene routes throw-tech assist mode to the dummy player")
 		var arena_node := training_node.get_node_or_null("Arena")
 		if arena_node != null:
 			_assert_true(bool(arena_node.get("side_platforms_enabled")), "training ruleset toggle enables side platforms")
@@ -1833,11 +1835,13 @@ func _test_training_toggle_keeps_dummy_non_ai() -> void:
 			"enabled": true,
 			"dummy_mode": "random_block",
 			"show_detail": true,
-			"ruleset_profile": "duel"
+			"ruleset_profile": "duel",
+			"throw_tech_assist_mode": "throw_only"
 		})
 		await process_frame
 		_assert_true(not bool(p2.get("is_ai")), "switching back to duel keeps dummy non-ai")
 		_assert_true(str(training_node.get("ruleset_profile")) == "duel", "training ruleset toggle can return to duel")
+		_assert_true(str(p2.get("training_throw_tech_assist_mode")) == "throw_only", "training scene can restore throw-only tech contract")
 	if is_instance_valid(training_node):
 		training_node.queue_free()
 	await process_frame
@@ -2103,26 +2107,49 @@ func _test_throw_tech_and_ai_defense_windows() -> void:
 
 	p1.set("is_ai", false)
 	p2.set("is_ai", false)
-	p2.set("current_hp", 100)
-	p2.set("hitstun_time", 0.0)
-	p2.set("blockstun_time", 0.0)
-	p2.set("is_knocked_down", false)
-	p2.set("getup_time", 0.0)
-	p2.set("wake_invuln_time", 0.0)
+	_reset_throw_tech_target_state(p2)
 
 	var throw_meta := {
 		"throw_techable": true,
 		"block_type": "throw",
 		"air_blockable": false
 	}
-	p2.set("throw_tech_buffer_time", 0.08)
+
+	_reset_throw_tech_target_state(p2)
+	p2.call("_prime_throw_tech_buffer", "light")
+	var duel_light_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
+	_assert_true(not bool(duel_light_result.get("throw_teched", false)), "duel throw tech ignores light mashing")
+
+	_reset_throw_tech_target_state(p2)
+	p2.call("_prime_throw_tech_buffer", "heavy")
+	var duel_heavy_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
+	_assert_true(not bool(duel_heavy_result.get("throw_teched", false)), "duel throw tech ignores heavy mashing")
+
+	_reset_throw_tech_target_state(p2)
+	p2.call("_prime_throw_tech_buffer", "throw")
 	var tech_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
 	_assert_true(bool(tech_result.get("throw_teched", false)), "throw tech succeeds inside tighter input buffer window")
+	_assert_true(str(tech_result.get("throw_tech_source", "")) == "throw", "throw tech records throw input as its source")
 
-	p2.set("current_hp", 100)
-	p2.set("throw_tech_buffer_time", 0.0)
+	_reset_throw_tech_target_state(p2)
+	p2.call("_clear_throw_tech_buffer")
 	var no_tech_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
 	_assert_true(not bool(no_tech_result.get("throw_teched", false)), "throw tech fails when buffer is not primed")
+
+	_reset_throw_tech_target_state(p2)
+	p2.call("set_training_throw_tech_options", true, "button_assist")
+	p2.call("_prime_throw_tech_buffer", "light")
+	var assist_light_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
+	_assert_true(bool(assist_light_result.get("throw_teched", false)), "training button assist allows light input to tech throws")
+	_assert_true(str(assist_light_result.get("throw_tech_window_type", "")) == "assist", "training button assist records assist window metadata")
+
+	_reset_throw_tech_target_state(p2)
+	p2.call("set_training_throw_tech_options", true, "off")
+	p2.call("_prime_throw_tech_buffer", "throw")
+	var assist_off_result: Dictionary = p2.call("apply_damage", 10, Vector2(110, -16), 0.12, "throw", throw_meta)
+	_assert_true(not bool(assist_off_result.get("throw_teched", false)), "training can disable throw-tech buffering entirely")
+
+	p2.call("set_training_throw_tech_options", false, "throw_only")
 
 	p2.set("is_ai", true)
 	p2.set("ai_block_time", 0.0)
@@ -2859,6 +2886,19 @@ func _spawn_test_players() -> Dictionary:
 	await process_frame
 	await process_frame
 	return {"host": host, "p1": p1, "p2": p2}
+
+func _reset_throw_tech_target_state(player: CharacterBody2D) -> void:
+	if player == null:
+		return
+	player.set("current_hp", 100)
+	player.set("hitstun_time", 0.0)
+	player.set("blockstun_time", 0.0)
+	player.set("is_knocked_down", false)
+	player.set("knockdown_time", 0.0)
+	player.set("getup_time", 0.0)
+	player.set("wake_invuln_time", 0.0)
+	player.set("velocity", Vector2.ZERO)
+	player.call("_clear_throw_tech_buffer")
 
 func _make_attack_template(damage: int, block_type: String, throw_techable: bool = false) -> Dictionary:
 	return {


### PR DESCRIPTION
Refs #2

## Summary
- split duel throw-tech inputs from training assist rules
- tighten the default duel tech window and record input source metadata
- add coverage for duel-only techs and training assist routing