### PR TITLE
Normalize generated signature profile contracts

### DIFF
--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -494,11 +494,11 @@ const STATUS_SLOW_CAP_SECONDS := 1.2
 const STATUS_ROOT_CAP_SECONDS := 0.5
 const CHARACTER_TINT_BY_ID := PlayerDataStore.CHARACTER_TINT_BY_ID
 const REQUIRED_BASE_ATTACK_KEYS := ["light", "heavy", "special", "throw"]
-const ARCHETYPE_ALL_ROUNDER := "all_rounder"
-const ARCHETYPE_RUSHDOWN := "rushdown"
-const ARCHETYPE_ZONER := "zoner"
-const ARCHETYPE_BRUISER := "bruiser"
-const ARCHETYPE_COUNTER := "counter"
+const ARCHETYPE_ALL_ROUNDER := PlayerDataStore.ARCHETYPE_ALL_ROUNDER
+const ARCHETYPE_RUSHDOWN := PlayerDataStore.ARCHETYPE_RUSHDOWN
+const ARCHETYPE_ZONER := PlayerDataStore.ARCHETYPE_ZONER
+const ARCHETYPE_BRUISER := PlayerDataStore.ARCHETYPE_BRUISER
+const ARCHETYPE_COUNTER := PlayerDataStore.ARCHETYPE_COUNTER
 const BLOCK_CHIP_BY_ATTACK := {
 	"light": 0.0,
 	"heavy": 0.08,
@@ -1938,21 +1938,7 @@ func get_character_profile() -> Dictionary:
 	}
 
 func _resolve_archetype_key() -> String:
-	var preferred_range := _get_ai_profile_number("preferred_range", 56.0)
-	var combo_pressure := _get_ai_profile_number("combo_pressure", 0.52)
-	var signature_bias := _get_ai_profile_number("signature_bias", 1.0)
-	var special_bias := _get_ai_profile_number("special_bias", 1.0)
-	var heavy_bias := _get_ai_profile_number("heavy_bias", 1.0)
-	var block_chance := _get_ai_profile_number("block_chance", 0.35)
-	if combo_pressure >= 0.66 and preferred_range <= 58.0:
-		return ARCHETYPE_RUSHDOWN
-	if preferred_range >= 72.0 and signature_bias >= 1.20 and heavy_bias <= 0.95:
-		return ARCHETYPE_ZONER
-	if heavy_bias >= 1.14 or special_bias >= 1.14:
-		return ARCHETYPE_BRUISER
-	if block_chance >= 0.40:
-		return ARCHETYPE_COUNTER
-	return ARCHETYPE_ALL_ROUNDER
+	return PlayerDataStore.resolve_archetype_key_from_ai_profile(ai_style_profile)
 
 func _resolve_archetype_label_key(archetype_key: String) -> String:
 	match archetype_key:

--- a/scripts/player/GeneratedSkillProfiles.gd
+++ b/scripts/player/GeneratedSkillProfiles.gd
@@ -1,6 +1,8 @@
 extends RefCounted
 class_name GeneratedSkillProfiles
 
+const PlayerDataStore := preload("res://scripts/player/PlayerData.gd")
+
 const PROFILE_BY_CHARACTER := {
 	"prototype_p1": {
 		"signature_a": {"damage_scale": 0.62, "cooldown": 1.4, "effect": {"type": "projectile", "speed": 300.0, "duration": 1.05, "size": Vector2(26, 16)}},
@@ -118,8 +120,180 @@ const PROFILE_BY_CHARACTER := {
 	}
 }
 
+const SLOT_KEYS := ["signature_a", "signature_b", "signature_c", "ultimate"]
+const SLOT_CONTRACT_FALLBACKS_BY_ARCHETYPE := {
+	PlayerDataStore.ARCHETYPE_ALL_ROUNDER: {
+		"signature_a": {"role": "pressure", "skeleton": "pressure_check"},
+		"signature_b": {"role": "approach", "skeleton": "dash_burst"},
+		"signature_c": {"role": "control", "skeleton": "control_snare"},
+		"ultimate": {"role": "super", "skeleton": "super_burst"}
+	},
+	PlayerDataStore.ARCHETYPE_RUSHDOWN: {
+		"signature_a": {"role": "pressure", "skeleton": "pressure_check"},
+		"signature_b": {"role": "approach", "skeleton": "dash_burst"},
+		"signature_c": {"role": "anti_air", "skeleton": "rising_launcher"},
+		"ultimate": {"role": "super", "skeleton": "super_burst"}
+	},
+	PlayerDataStore.ARCHETYPE_ZONER: {
+		"signature_a": {"role": "pressure", "skeleton": "projectile_check"},
+		"signature_b": {"role": "approach", "skeleton": "teleport_punish"},
+		"signature_c": {"role": "setplay", "skeleton": "trap_setplay"},
+		"ultimate": {"role": "super", "skeleton": "screen_control_super"}
+	},
+	PlayerDataStore.ARCHETYPE_BRUISER: {
+		"signature_a": {"role": "pressure", "skeleton": "pressure_check"},
+		"signature_b": {"role": "approach", "skeleton": "rising_launcher"},
+		"signature_c": {"role": "control", "skeleton": "control_snare"},
+		"ultimate": {"role": "super", "skeleton": "super_burst"}
+	},
+	PlayerDataStore.ARCHETYPE_COUNTER: {
+		"signature_a": {"role": "control", "skeleton": "control_poke"},
+		"signature_b": {"role": "approach", "skeleton": "teleport_punish"},
+		"signature_c": {"role": "control", "skeleton": "control_snare"},
+		"ultimate": {"role": "install", "skeleton": "install_overclock"}
+	}
+}
+
 static func get_profile(character_id: String) -> Dictionary:
 	var value: Variant = PROFILE_BY_CHARACTER.get(character_id, {})
 	if typeof(value) != TYPE_DICTIONARY:
 		return {}
-	return (value as Dictionary).duplicate(true)
+	return _normalize_profile(character_id, (value as Dictionary).duplicate(true))
+
+static func get_generated_archetype(profile: Dictionary) -> String:
+	return str(profile.get("generated_archetype", PlayerDataStore.ARCHETYPE_ALL_ROUNDER))
+
+static func get_slot_contract(profile: Dictionary, slot_key: String) -> Dictionary:
+	var slot_contracts_value: Variant = profile.get("slot_contracts", {})
+	if typeof(slot_contracts_value) == TYPE_DICTIONARY:
+		var slot_contracts := slot_contracts_value as Dictionary
+		var contract_value: Variant = slot_contracts.get(slot_key, {})
+		if typeof(contract_value) == TYPE_DICTIONARY:
+			return (contract_value as Dictionary).duplicate(true)
+	var entry_value: Variant = profile.get(slot_key, {})
+	if typeof(entry_value) != TYPE_DICTIONARY:
+		return {}
+	var entry := entry_value as Dictionary
+	return _build_slot_contract(
+		slot_key,
+		str(entry.get("role", "")),
+		str(entry.get("skeleton", ""))
+	)
+
+static func _normalize_profile(character_id: String, profile: Dictionary) -> Dictionary:
+	var normalized := profile.duplicate(true)
+	var generated_archetype := str(normalized.get(
+		"generated_archetype",
+		PlayerDataStore.resolve_character_archetype(character_id)
+	)).strip_edges().to_lower()
+	if generated_archetype == "":
+		generated_archetype = PlayerDataStore.ARCHETYPE_ALL_ROUNDER
+	normalized["generated_archetype"] = generated_archetype
+	var slot_contracts := {}
+	for slot_key in SLOT_KEYS:
+		var entry_value: Variant = normalized.get(slot_key, {})
+		if typeof(entry_value) != TYPE_DICTIONARY:
+			continue
+		var entry := (entry_value as Dictionary).duplicate(true)
+		var contract := _resolve_slot_contract(slot_key, entry, generated_archetype)
+		entry["slot_key"] = slot_key
+		entry["generated_archetype"] = generated_archetype
+		entry["role"] = str(contract.get("role", ""))
+		entry["skeleton"] = str(contract.get("skeleton", ""))
+		normalized[slot_key] = entry
+		slot_contracts[slot_key] = contract
+	normalized["slot_contracts"] = slot_contracts
+	return normalized
+
+static func _resolve_slot_contract(slot_key: String, entry: Dictionary, generated_archetype: String) -> Dictionary:
+	var fallback := _get_archetype_slot_contract(generated_archetype, slot_key)
+	var role := str(entry.get("role", "")).strip_edges().to_lower()
+	var skeleton := str(entry.get("skeleton", "")).strip_edges().to_lower()
+	if role != "" and skeleton != "":
+		return _build_slot_contract(slot_key, role, skeleton)
+	var inferred := _infer_slot_contract_from_payload(slot_key, entry, fallback)
+	if role == "":
+		role = str(inferred.get("role", fallback.get("role", ""))).strip_edges().to_lower()
+	if skeleton == "":
+		skeleton = str(inferred.get("skeleton", fallback.get("skeleton", ""))).strip_edges().to_lower()
+	return _build_slot_contract(slot_key, role, skeleton)
+
+static func _get_archetype_slot_contract(generated_archetype: String, slot_key: String) -> Dictionary:
+	var contract_map_value: Variant = SLOT_CONTRACT_FALLBACKS_BY_ARCHETYPE.get(
+		generated_archetype,
+		SLOT_CONTRACT_FALLBACKS_BY_ARCHETYPE[PlayerDataStore.ARCHETYPE_ALL_ROUNDER]
+	)
+	if typeof(contract_map_value) != TYPE_DICTIONARY:
+		return {}
+	var contract_map := contract_map_value as Dictionary
+	var contract_value: Variant = contract_map.get(slot_key, {})
+	if typeof(contract_value) != TYPE_DICTIONARY:
+		return {}
+	var contract := contract_value as Dictionary
+	return _build_slot_contract(
+		slot_key,
+		str(contract.get("role", "")),
+		str(contract.get("skeleton", ""))
+	)
+
+static func _infer_slot_contract_from_payload(slot_key: String, entry: Dictionary, fallback: Dictionary) -> Dictionary:
+	var effect_type := _resolve_effect_type(entry)
+	var effect_mode := _resolve_effect_mode(entry)
+	if slot_key == "ultimate":
+		match effect_type:
+			"buff":
+				return _build_slot_contract(slot_key, "install", "install_overclock")
+			"projectile", "trap", "summon":
+				return _build_slot_contract(slot_key, "super", "screen_control_super")
+		return fallback
+	match effect_type:
+		"mobility":
+			if effect_mode == "rising":
+				return _build_slot_contract(slot_key, "anti_air" if slot_key == "signature_c" else "approach", "rising_launcher")
+			if effect_mode == "teleport":
+				return _build_slot_contract(slot_key, "approach", "teleport_punish")
+			return _build_slot_contract(slot_key, "approach", "dash_burst")
+		"projectile":
+			if slot_key == "signature_c":
+				return _build_slot_contract(slot_key, "control", "projectile_screen")
+			return _build_slot_contract(slot_key, "pressure", "projectile_check")
+		"trap":
+			if slot_key == "signature_a":
+				return _build_slot_contract(slot_key, "setplay", "trap_seed")
+			return _build_slot_contract(slot_key, "setplay", "trap_setplay")
+		"summon":
+			if slot_key == "signature_a":
+				return _build_slot_contract(slot_key, "pressure", "summon_check")
+			return _build_slot_contract(slot_key, "setplay", "summon_screen")
+		"buff":
+			return _build_slot_contract(slot_key, "install", "install_pulse")
+	if _has_control_payload(entry):
+		if slot_key == "signature_a":
+			return _build_slot_contract(slot_key, "control", "control_poke")
+		return _build_slot_contract(slot_key, "control", "control_snare")
+	return fallback
+
+static func _resolve_effect_type(entry: Dictionary) -> String:
+	var effect_value: Variant = entry.get("effect", {})
+	if typeof(effect_value) != TYPE_DICTIONARY:
+		return ""
+	return str((effect_value as Dictionary).get("type", "")).strip_edges().to_lower()
+
+static func _resolve_effect_mode(entry: Dictionary) -> String:
+	var effect_value: Variant = entry.get("effect", {})
+	if typeof(effect_value) != TYPE_DICTIONARY:
+		return ""
+	return str((effect_value as Dictionary).get("mode", "")).strip_edges().to_lower()
+
+static func _has_control_payload(entry: Dictionary) -> bool:
+	var control_value: Variant = entry.get("control", {})
+	if typeof(control_value) != TYPE_DICTIONARY:
+		return false
+	return not (control_value as Dictionary).is_empty()
+
+static func _build_slot_contract(slot_key: String, role: String, skeleton: String) -> Dictionary:
+	return {
+		"slot_key": slot_key,
+		"role": role,
+		"skeleton": skeleton
+	}

--- a/scripts/player/PlayerData.gd
+++ b/scripts/player/PlayerData.gd
@@ -1,6 +1,12 @@
 extends RefCounted
 class_name PlayerData
 
+const ARCHETYPE_ALL_ROUNDER := "all_rounder"
+const ARCHETYPE_RUSHDOWN := "rushdown"
+const ARCHETYPE_ZONER := "zoner"
+const ARCHETYPE_BRUISER := "bruiser"
+const ARCHETYPE_COUNTER := "counter"
+
 const AI_PROFILE_DEFAULT := {
 	"preferred_range": 56.0,
 	"chase_range": 108.0,
@@ -149,3 +155,33 @@ const ATTACK_DATA := {
 		"hitbox_offset_ground": Vector2(18, 0), "hitbox_offset_air": Vector2(18, -6)
 	}
 }
+
+static func get_ai_profile(character_id: String) -> Dictionary:
+	var profile := AI_PROFILE_DEFAULT.duplicate(true)
+	var override_value: Variant = AI_PROFILE_BY_CHARACTER.get(character_id, {})
+	if typeof(override_value) != TYPE_DICTIONARY:
+		return profile
+	var overrides := override_value as Dictionary
+	for key in overrides.keys():
+		profile[str(key)] = overrides[key]
+	return profile
+
+static func resolve_archetype_key_from_ai_profile(ai_profile: Dictionary) -> String:
+	var preferred_range := float(ai_profile.get("preferred_range", 56.0))
+	var combo_pressure := float(ai_profile.get("combo_pressure", 0.52))
+	var signature_bias := float(ai_profile.get("signature_bias", 1.0))
+	var special_bias := float(ai_profile.get("special_bias", 1.0))
+	var heavy_bias := float(ai_profile.get("heavy_bias", 1.0))
+	var block_chance := float(ai_profile.get("block_chance", 0.35))
+	if combo_pressure >= 0.66 and preferred_range <= 58.0:
+		return ARCHETYPE_RUSHDOWN
+	if preferred_range >= 72.0 and signature_bias >= 1.20 and heavy_bias <= 0.95:
+		return ARCHETYPE_ZONER
+	if heavy_bias >= 1.14 or special_bias >= 1.14:
+		return ARCHETYPE_BRUISER
+	if block_chance >= 0.40:
+		return ARCHETYPE_COUNTER
+	return ARCHETYPE_ALL_ROUNDER
+
+static func resolve_character_archetype(character_id: String) -> String:
+	return resolve_archetype_key_from_ai_profile(get_ai_profile(character_id))

--- a/tests/TestRunner.gd
+++ b/tests/TestRunner.gd
@@ -10,6 +10,7 @@ const EvolutionEngineStore := preload("res://scripts/loadout/EvolutionEngine.gd"
 const RoundTuningEngineStore := preload("res://scripts/loadout/RoundTuningEngine.gd")
 const AttackTableStore := preload("res://scripts/resources/AttackTable.gd")
 const GeneratedSkillProfilesStore := preload("res://scripts/player/GeneratedSkillProfiles.gd")
+const PlayerDataStore := preload("res://scripts/player/PlayerData.gd")
 const REQUIRED_BASE_ATTACKS := ["light", "heavy", "special", "throw"]
 const SUITE_SMOKE := "smoke"
 const SUITE_FULL := "full"
@@ -66,6 +67,7 @@ func _run_smoke_suite() -> void:
 	await _test_loadout_item_trigger_and_cooldown_runtime()
 	await _test_loadout_item_evolution_boundaries()
 	await _test_loadout_wave1_tuning_profiles_present()
+	await _test_generated_signature_profiles_are_normalized()
 	await _test_round_tuning_intermission_flow()
 	await _test_round_tuning_simultaneous_stock_fairness()
 	await _test_round_tuning_pick_cap_per_player()
@@ -1380,6 +1382,37 @@ func _test_loadout_wave1_tuning_profiles_present() -> void:
 		is_equal_approx(float(sam_core.get("cooldown_seconds", 6.0)), 5.5),
 		"wave1 tuning applies Sam core cooldown adjustment"
 	)
+
+func _test_generated_signature_profiles_are_normalized() -> void:
+	for character_id_variant in GeneratedSkillProfilesStore.PROFILE_BY_CHARACTER.keys():
+		var character_id := str(character_id_variant)
+		var profile := GeneratedSkillProfilesStore.get_profile(character_id)
+		_assert_true(not profile.is_empty(), "normalized generated profile loads for %s" % character_id)
+		var generated_archetype := str(profile.get("generated_archetype", ""))
+		_assert_true(generated_archetype != "", "normalized generated profile exposes archetype for %s" % character_id)
+		_assert_true(
+			generated_archetype == PlayerDataStore.resolve_character_archetype(character_id),
+			"normalized generated profile archetype matches shared resolver for %s" % character_id
+		)
+		var slot_contracts_value: Variant = profile.get("slot_contracts", {})
+		_assert_true(typeof(slot_contracts_value) == TYPE_DICTIONARY, "normalized generated profile exposes slot contracts for %s" % character_id)
+		var slot_contracts := {}
+		if typeof(slot_contracts_value) == TYPE_DICTIONARY:
+			slot_contracts = slot_contracts_value as Dictionary
+		for slot_key in ["signature_a", "signature_b", "signature_c", "ultimate"]:
+			var entry_value: Variant = profile.get(slot_key, {})
+			_assert_true(typeof(entry_value) == TYPE_DICTIONARY, "%s profile keeps %s entry as dictionary" % [character_id, slot_key])
+			if typeof(entry_value) != TYPE_DICTIONARY:
+				continue
+			var entry := entry_value as Dictionary
+			var contract := GeneratedSkillProfilesStore.get_slot_contract(profile, slot_key)
+			_assert_true(str(entry.get("slot_key", "")) == slot_key, "%s profile annotates slot key for %s" % [character_id, slot_key])
+			_assert_true(str(entry.get("generated_archetype", "")) == generated_archetype, "%s profile entry inherits archetype for %s" % [character_id, slot_key])
+			_assert_true(str(entry.get("role", "")) != "", "%s profile entry exposes role for %s" % [character_id, slot_key])
+			_assert_true(str(entry.get("skeleton", "")) != "", "%s profile entry exposes skeleton for %s" % [character_id, slot_key])
+			_assert_true(not slot_contracts.is_empty() and slot_contracts.has(slot_key), "%s slot contract map includes %s" % [character_id, slot_key])
+			_assert_true(str(contract.get("role", "")) == str(entry.get("role", "")), "%s slot contract role matches entry for %s" % [character_id, slot_key])
+			_assert_true(str(contract.get("skeleton", "")) == str(entry.get("skeleton", "")), "%s slot contract skeleton matches entry for %s" % [character_id, slot_key])
 
 func _test_match_metrics_telemetry_schema() -> void:
 	var metrics_path := ProjectSettings.globalize_path("user://match_metrics.jsonl")


### PR DESCRIPTION
## Summary
- normalize generated signature profiles around shared archetype, role, and skeleton metadata
- move archetype resolution into PlayerData so runtime and generators use the same contract
- add smoke coverage that validates every generated roster profile exposes normalized slot contracts

## Testing
- just test smoke