### PR TITLE
Enforce generated signature roles across loadouts

### DIFF
--- a/scripts/config/LoadoutCatalog.gd
+++ b/scripts/config/LoadoutCatalog.gd
@@ -195,12 +195,12 @@ static func _build_skill_defs(character_id: String, profile: Dictionary) -> Arra
 	var ultimate_damage_multiplier := float(tuning.get("ultimate_damage_multiplier", 1.0))
 	var ultimate_cooldown_multiplier := float(tuning.get("ultimate_cooldown_multiplier", 1.0))
 	return [
-		_build_skill_def(character_id, "signature_a", "core", 2, PackedStringArray(["neutral_tool"]), signature_a, 1.00 * signature_damage_multiplier, 1.00 * signature_cooldown_multiplier, str(move_names.get("signature_a", "Signature A")), "Core"),
-		_build_skill_def(character_id, "signature_a", "burst", 2, PackedStringArray(["high_chip"]), signature_a, 1.12 * signature_damage_multiplier, 1.08 * signature_cooldown_multiplier, str(move_names.get("signature_a", "Signature A")), "Burst"),
-		_build_skill_def(character_id, "signature_b", "mobility", 2, PackedStringArray(["burst_mobility"]), signature_b, 1.00 * signature_damage_multiplier, 0.96 * signature_cooldown_multiplier, str(move_names.get("signature_b", "Signature B")), "Mobility"),
-		_build_skill_def(character_id, "signature_b", "control", 2, PackedStringArray(["hard_cc"]), signature_b, 0.92 * signature_damage_multiplier, 1.00 * signature_cooldown_multiplier, str(move_names.get("signature_b", "Signature B")), "Control"),
-		_build_skill_def(character_id, "ultimate", "core", 2, PackedStringArray(["neutral_tool"]), ultimate, 1.00 * ultimate_damage_multiplier, 1.00 * ultimate_cooldown_multiplier, str(move_names.get("ultimate", "Ultimate")), "Core"),
-		_build_skill_def(character_id, "ultimate", "overclock", 3, PackedStringArray(["neutral_tool"]), ultimate, 1.10 * ultimate_damage_multiplier, 1.10 * ultimate_cooldown_multiplier, str(move_names.get("ultimate", "Ultimate")), "Overclock")
+		_build_skill_def(character_id, "signature_a", "core", 2, _compose_skill_tags(PackedStringArray(["neutral_tool"]), signature_a), signature_a, 1.00 * signature_damage_multiplier, 1.00 * signature_cooldown_multiplier, str(move_names.get("signature_a", "Signature A")), _resolve_skill_variant_label("signature_a", "core", signature_a, "Core")),
+		_build_skill_def(character_id, "signature_a", "burst", 2, _compose_skill_tags(PackedStringArray(["high_chip"]), signature_a), signature_a, 1.12 * signature_damage_multiplier, 1.08 * signature_cooldown_multiplier, str(move_names.get("signature_a", "Signature A")), _resolve_skill_variant_label("signature_a", "burst", signature_a, "Burst")),
+		_build_skill_def(character_id, "signature_b", "mobility", 2, _compose_skill_tags(PackedStringArray(["burst_mobility"]), signature_b), signature_b, 1.00 * signature_damage_multiplier, 0.96 * signature_cooldown_multiplier, str(move_names.get("signature_b", "Signature B")), _resolve_skill_variant_label("signature_b", "mobility", signature_b, "Mobility")),
+		_build_skill_def(character_id, "signature_b", "control", 2, _compose_skill_tags(PackedStringArray(["hard_cc"]), signature_b), signature_b, 0.92 * signature_damage_multiplier, 1.00 * signature_cooldown_multiplier, str(move_names.get("signature_b", "Signature B")), _resolve_skill_variant_label("signature_b", "control", signature_b, "Control")),
+		_build_skill_def(character_id, "ultimate", "core", 2, _compose_skill_tags(PackedStringArray(["neutral_tool"]), ultimate), ultimate, 1.00 * ultimate_damage_multiplier, 1.00 * ultimate_cooldown_multiplier, str(move_names.get("ultimate", "Ultimate")), _resolve_skill_variant_label("ultimate", "core", ultimate, "Core")),
+		_build_skill_def(character_id, "ultimate", "overclock", 3, _compose_skill_tags(PackedStringArray(["neutral_tool"]), ultimate), ultimate, 1.10 * ultimate_damage_multiplier, 1.10 * ultimate_cooldown_multiplier, str(move_names.get("ultimate", "Ultimate")), _resolve_skill_variant_label("ultimate", "overclock", ultimate, "Overclock"))
 	]
 
 static func _build_skill_def(
@@ -218,6 +218,8 @@ static func _build_skill_def(
 	var skill_id := "%s_%s_%s" % [character_id, slot_key, variant]
 	var cooldown := maxf(0.35, float(profile_entry.get("cooldown", 1.6)) * cooldown_multiplier)
 	var base_damage_scale := float(profile_entry.get("damage_scale", 0.62))
+	var generated_role := _resolve_profile_role(profile_entry)
+	var generated_skeleton := _resolve_profile_skeleton(profile_entry)
 	var resolved_base_name := base_name.strip_edges()
 	if resolved_base_name == "":
 		resolved_base_name = _slot_fallback_name(slot_key)
@@ -225,7 +227,9 @@ static func _build_skill_def(
 	var attack_patch := {
 		"damage_scale": clampf(base_damage_scale * damage_scale_multiplier, 0.35, 1.80),
 		"cooldown": cooldown,
-		"display_name": display_name
+		"display_name": display_name,
+		"generated_role": generated_role,
+		"generated_skeleton": generated_skeleton
 	}
 	if profile_entry.has("effect"):
 		var effect_value: Variant = profile_entry.get("effect", {})
@@ -248,6 +252,8 @@ static func _build_skill_def(
 		"display_name_fallback": display_name,
 		"slot_type": "ultimate" if slot_key == "ultimate" else "signature",
 		"slot_key": slot_key,
+		"generated_role": generated_role,
+		"generated_skeleton": generated_skeleton,
 		"cost": cost,
 		"tags": tags,
 		"attack_entry_key": slot_key,
@@ -255,6 +261,55 @@ static func _build_skill_def(
 		"attack_patch": attack_patch,
 		"selectable": true
 	}
+
+static func _compose_skill_tags(base_tags: PackedStringArray, profile_entry: Dictionary) -> PackedStringArray:
+	var tags := PackedStringArray()
+	for tag in base_tags:
+		tags.append(str(tag))
+	var generated_role := _resolve_profile_role(profile_entry, "")
+	if generated_role != "":
+		var role_tag := "role_%s" % generated_role
+		if not tags.has(role_tag):
+			tags.append(role_tag)
+	return tags
+
+static func _resolve_skill_variant_label(slot_key: String, variant: String, profile_entry: Dictionary, fallback: String) -> String:
+	var generated_role := _resolve_profile_role(profile_entry, "")
+	match slot_key:
+		"signature_a":
+			if variant == "core":
+				match generated_role:
+					"control":
+						return "Control"
+					"setplay":
+						return "Setup"
+					_:
+						return "Pressure"
+			if variant == "burst":
+				match generated_role:
+					"control":
+						return "Crush"
+					"setplay":
+						return "Snare"
+					_:
+						return "Burst"
+		"signature_b":
+			if variant == "mobility":
+				return "Pursuit"
+			if variant == "control":
+				return "Punish"
+		"ultimate":
+			if variant == "core":
+				return "Install" if generated_role == "install" else "Finisher"
+			if variant == "overclock":
+				return "Overclock"
+	return fallback
+
+static func _resolve_profile_role(profile_entry: Dictionary, fallback: String = "pressure") -> String:
+	return str(profile_entry.get("role", fallback)).strip_edges().to_lower()
+
+static func _resolve_profile_skeleton(profile_entry: Dictionary) -> String:
+	return str(profile_entry.get("skeleton", "")).strip_edges().to_lower()
 
 static func _build_item_defs(character_id: String) -> Array[Dictionary]:
 	var core_id := "%s_item_brand_core" % character_id

--- a/scripts/player/GeneratedSkillProfiles.gd
+++ b/scripts/player/GeneratedSkillProfiles.gd
@@ -153,6 +153,49 @@ const SLOT_CONTRACT_FALLBACKS_BY_ARCHETYPE := {
 		"ultimate": {"role": "install", "skeleton": "install_overclock"}
 	}
 }
+const ALLOWED_ROLES_BY_SLOT := {
+	"signature_a": {"pressure": true, "control": true},
+	"signature_b": {"approach": true},
+	"signature_c": {"control": true, "setplay": true, "anti_air": true},
+	"ultimate": {"super": true, "install": true}
+}
+const SKELETONS_BY_ROLE := {
+	"pressure": {
+		"pressure_check": true,
+		"projectile_check": true,
+		"summon_check": true,
+		"trap_seed": true,
+		"control_poke": true
+	},
+	"approach": {
+		"dash_burst": true,
+		"teleport_punish": true,
+		"rising_launcher": true
+	},
+	"control": {
+		"control_poke": true,
+		"control_snare": true,
+		"projectile_screen": true,
+		"summon_screen": true
+	},
+	"setplay": {
+		"trap_seed": true,
+		"trap_setplay": true,
+		"projectile_screen": true,
+		"summon_screen": true
+	},
+	"anti_air": {
+		"rising_launcher": true
+	},
+	"install": {
+		"install_pulse": true,
+		"install_overclock": true
+	},
+	"super": {
+		"super_burst": true,
+		"screen_control_super": true
+	}
+}
 
 static func get_profile(character_id: String) -> Dictionary:
 	var value: Variant = PROFILE_BY_CHARACTER.get(character_id, {})
@@ -206,16 +249,14 @@ static func _normalize_profile(character_id: String, profile: Dictionary) -> Dic
 	return normalized
 
 static func _resolve_slot_contract(slot_key: String, entry: Dictionary, generated_archetype: String) -> Dictionary:
-	var fallback := _get_archetype_slot_contract(generated_archetype, slot_key)
-	var role := str(entry.get("role", "")).strip_edges().to_lower()
-	var skeleton := str(entry.get("skeleton", "")).strip_edges().to_lower()
-	if role != "" and skeleton != "":
-		return _build_slot_contract(slot_key, role, skeleton)
-	var inferred := _infer_slot_contract_from_payload(slot_key, entry, fallback)
-	if role == "":
-		role = str(inferred.get("role", fallback.get("role", ""))).strip_edges().to_lower()
-	if skeleton == "":
-		skeleton = str(inferred.get("skeleton", fallback.get("skeleton", ""))).strip_edges().to_lower()
+	var preferred := _get_archetype_slot_contract(generated_archetype, slot_key)
+	var inferred := _infer_slot_contract_from_payload(slot_key, entry, preferred)
+	var role := str(entry.get("role", inferred.get("role", preferred.get("role", "")))).strip_edges().to_lower()
+	if not _is_role_allowed_for_slot(slot_key, role):
+		role = str(preferred.get("role", role)).strip_edges().to_lower()
+	var skeleton := str(entry.get("skeleton", inferred.get("skeleton", ""))).strip_edges().to_lower()
+	if skeleton == "" or not _does_skeleton_match_role(skeleton, role):
+		skeleton = _resolve_skeleton_for_role(role, slot_key, entry, preferred)
 	return _build_slot_contract(slot_key, role, skeleton)
 
 static func _get_archetype_slot_contract(generated_archetype: String, slot_key: String) -> Dictionary:
@@ -272,6 +313,64 @@ static func _infer_slot_contract_from_payload(slot_key: String, entry: Dictionar
 			return _build_slot_contract(slot_key, "control", "control_poke")
 		return _build_slot_contract(slot_key, "control", "control_snare")
 	return fallback
+
+static func _is_role_allowed_for_slot(slot_key: String, role: String) -> bool:
+	var allowed_value: Variant = ALLOWED_ROLES_BY_SLOT.get(slot_key, {})
+	if typeof(allowed_value) != TYPE_DICTIONARY:
+		return role != ""
+	var allowed_roles := allowed_value as Dictionary
+	return role != "" and allowed_roles.has(role)
+
+static func _does_skeleton_match_role(skeleton: String, role: String) -> bool:
+	var role_value: Variant = SKELETONS_BY_ROLE.get(role, {})
+	if typeof(role_value) != TYPE_DICTIONARY:
+		return false
+	return (role_value as Dictionary).has(skeleton)
+
+static func _resolve_skeleton_for_role(role: String, slot_key: String, entry: Dictionary, fallback: Dictionary) -> String:
+	var effect_type := _resolve_effect_type(entry)
+	var effect_mode := _resolve_effect_mode(entry)
+	match role:
+		"pressure":
+			if effect_type == "projectile":
+				return "projectile_check"
+			if effect_type == "summon":
+				return "summon_check"
+			if effect_type == "trap":
+				return "trap_seed"
+			if slot_key == "signature_a" and _has_control_payload(entry):
+				return "control_poke"
+			return str(fallback.get("skeleton", "pressure_check"))
+		"approach":
+			if effect_type == "mobility":
+				if effect_mode == "teleport":
+					return "teleport_punish"
+				if effect_mode == "rising":
+					return "rising_launcher"
+			return "dash_burst"
+		"control":
+			if effect_type == "projectile":
+				return "projectile_screen"
+			if effect_type == "summon":
+				return "summon_screen"
+			if slot_key == "signature_a":
+				return "control_poke"
+			return "control_snare"
+		"setplay":
+			if effect_type == "projectile":
+				return "projectile_screen"
+			if effect_type == "summon":
+				return "summon_screen"
+			return "trap_seed" if slot_key == "signature_a" else "trap_setplay"
+		"anti_air":
+			return "rising_launcher"
+		"install":
+			return "install_overclock" if slot_key == "ultimate" else "install_pulse"
+		"super":
+			if effect_type in ["projectile", "trap", "summon"]:
+				return "screen_control_super"
+			return "super_burst"
+	return str(fallback.get("skeleton", "pressure_check"))
 
 static func _resolve_effect_type(entry: Dictionary) -> String:
 	var effect_value: Variant = entry.get("effect", {})

--- a/tests/TestRunner.gd
+++ b/tests/TestRunner.gd
@@ -1141,6 +1141,15 @@ func _test_loadout_system_foundation() -> void:
 		str(signature_a_core.get("display_name_fallback", "")).find("GPT Burst") != -1,
 		"loadout skills inherit character-specific signature names instead of generic slot labels"
 	)
+	_assert_true(
+		str(signature_a_core.get("generated_role", "")) == str(GeneratedSkillProfilesStore.get_profile(character_id).get("signature_a", {}).get("role", "")),
+		"loadout skills carry generated role metadata from normalized signature profiles"
+	)
+	var ultimate_core := skill_by_id.get("%s_ultimate_core" % character_id, {}) as Dictionary
+	_assert_true(
+		str(ultimate_core.get("display_name_fallback", "")).find("(Install)") != -1,
+		"install-style ultimate loadout skills surface role-aware variant labels"
+	)
 
 func _test_loadout_session_flow_runtime_apply() -> void:
 	var menu_packed := load("res://scenes/Menu.tscn")
@@ -1428,9 +1437,12 @@ func _test_generated_signature_builder_uses_role_skeletons() -> void:
 	distorted_special["lunge_speed"] = 0.0
 	distorted_special["hitbox_size_ground"] = Vector2(80, 80)
 	distorted_special["hitbox_offset_ground"] = Vector2(-30, -30)
-	for character_id in ["bill_geytz", "larry_pagyr", "tim_cuke", "travis_kalanik"]:
+	for character_id_variant in GeneratedSkillProfilesStore.PROFILE_BY_CHARACTER.keys():
+		var character_id := str(character_id_variant)
 		var profile := GeneratedSkillProfilesStore.get_profile(character_id)
 		var unique_skeletons := {}
+		var unique_roles := {}
+		var unique_fingerprints := {}
 		for slot_key in ["signature_a", "signature_b", "signature_c", "ultimate"]:
 			var config_value: Variant = profile.get(slot_key, {})
 			_assert_true(typeof(config_value) == TYPE_DICTIONARY, "%s builder test resolves %s config" % [character_id, slot_key])
@@ -1458,8 +1470,23 @@ func _test_generated_signature_builder_uses_role_skeletons() -> void:
 				or not is_equal_approx(float(generated.get("lunge_speed", 0.0)), float(special_base.get("lunge_speed", 0.0)))
 			)
 			_assert_true(differs_from_special, "%s generated %s differs from the base special profile" % [character_id, slot_key])
+			unique_roles[str(generated.get("generated_role", ""))] = true
 			unique_skeletons[str(generated.get("generated_skeleton", ""))] = true
+			unique_fingerprints[_signature_attack_fingerprint(generated)] = true
+		_assert_true(unique_roles.size() >= 3, "%s generated kit exposes at least three distinct roles" % character_id)
 		_assert_true(unique_skeletons.size() >= 3, "%s generated kit exposes at least three distinct skeletons" % character_id)
+		_assert_true(unique_fingerprints.size() >= 3, "%s generated kit exposes at least three distinct gameplay fingerprints" % character_id)
+
+func _signature_attack_fingerprint(entry: Dictionary) -> String:
+	return "%s|%s|%.2f|%s|%s|%s|%s" % [
+		str(entry.get("block_type", "")),
+		str(entry.get("generated_skeleton", "")),
+		float(entry.get("lunge_speed", 0.0)),
+		str(entry.get("hitbox_size_ground", Vector2.ZERO)),
+		str(entry.get("hitbox_offset_ground", Vector2.ZERO)),
+		str(entry.get("knockback_ground", Vector2.ZERO)),
+		str(entry.get("cancel_options", []))
+	]
 
 func _test_match_metrics_telemetry_schema() -> void:
 	var metrics_path := ProjectSettings.globalize_path("user://match_metrics.jsonl")


### PR DESCRIPTION
## Summary
- enforce slot-specific generated roles and skeleton compatibility so A/B/C/U kits keep distinct gameplay jobs
- thread normalized role metadata through loadout generation for clearer tags, labels, and downstream tuning hooks
- expand smoke coverage to full-roster kit differentiation and role-aware loadout labeling

## Testing
- just test smoke